### PR TITLE
Fixed Badge that referred to wrong package

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The MIT License (MIT). Please see [LICENSE](LICENSE) for more information.
 
 [ico-version]: https://img.shields.io/packagist/v/middlewares/skeleton.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-ga]: https://github.com/middlewares/minifier/workflows/testing/badge.svg
+[ico-ga]: https://github.com/middlewares/skeleton/workflows/testing/badge.svg
 [ico-downloads]: https://img.shields.io/packagist/dt/middlewares/skeleton.svg?style=flat-square
 
 [link-packagist]: https://packagist.org/packages/middlewares/skeleton


### PR DESCRIPTION
Corrected badge link that was pulling from the wrong badge.