### PR TITLE
Removed deprecated option `--no-suggest`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
 
             - name: Install dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'
-              run: composer install --prefer-dist --no-progress --no-suggest
+              run: composer install --prefer-dist --no-progress
 
             - name: Coding Standard
               run: composer run-script cs
@@ -67,7 +67,7 @@ jobs:
                   restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
             - name: Install dependencies
-              run: composer install --prefer-dist --no-progress --no-suggest ${{ matrix.composer-args }}
+              run: composer install --prefer-dist --no-progress ${{ matrix.composer-args }}
 
             - name: Tests
               run: composer test


### PR DESCRIPTION
The use of `--no-suggest` causes the following message,  `You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.` in preparation for composer 3 this flag needs to be removed.